### PR TITLE
22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [2025-05-24] [basic renderer](https://github.com/RubricLab/blocks/commit/c69c2466ca2ca302498372201c79483e1e86c5c3)
 - [2025-05-22] [bump zod](https://github.com/RubricLab/blocks/commit/df96a8e52809595876d8add5f56391fb38e4b7d6)
 - [2025-05-21] [init rebuild](https://github.com/RubricLab/blocks/commit/4ebb0e53b6625eb7563b1512cacb90553f69cb7a)
 - [2025-04-29] [block chaining first pass with response_format](https://github.com/RubricLab/blocks/commit/594a2904ddef4d21f47ba5cd010d6c568979e493)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [2025-05-22] [bump zod](https://github.com/RubricLab/blocks/commit/df96a8e52809595876d8add5f56391fb38e4b7d6)
 - [2025-05-21] [init rebuild](https://github.com/RubricLab/blocks/commit/4ebb0e53b6625eb7563b1512cacb90553f69cb7a)
 - [2025-04-29] [block chaining first pass with response_format](https://github.com/RubricLab/blocks/commit/594a2904ddef4d21f47ba5cd010d6c568979e493)
 - [2024-10-24] [add notify-monorepo action](https://github.com/RubricLab/blocks/commit/b6352a719df1d93ac0e5663b733050da7e409293)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [2025-05-27] [zod latest](https://github.com/RubricLab/blocks/commit/858b707b0c761cbd9cc9c7f000066fa37f06bdf0)
 - [2025-05-24] [basic renderer](https://github.com/RubricLab/blocks/commit/c69c2466ca2ca302498372201c79483e1e86c5c3)
 - [2025-05-22] [bump zod](https://github.com/RubricLab/blocks/commit/df96a8e52809595876d8add5f56391fb38e4b7d6)
 - [2025-05-21] [init rebuild](https://github.com/RubricLab/blocks/commit/4ebb0e53b6625eb7563b1512cacb90553f69cb7a)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [2025-05-21] [init rebuild](https://github.com/RubricLab/blocks/commit/4ebb0e53b6625eb7563b1512cacb90553f69cb7a)
 - [2025-04-29] [block chaining first pass with response_format](https://github.com/RubricLab/blocks/commit/594a2904ddef4d21f47ba5cd010d6c568979e493)
 - [2024-10-24] [add notify-monorepo action](https://github.com/RubricLab/blocks/commit/b6352a719df1d93ac0e5663b733050da7e409293)
 - [2024-10-03] [mod lint script](https://github.com/RubricLab/blocks/commit/5bc324c8cefd0f7bb66e3489a9379436451c01e9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [2025-05-30] [stash wip](https://github.com/RubricLab/blocks/commit/71271bd3cc2701dcfd50976db218156b09f410d3)
 - [2025-05-27] [zod latest](https://github.com/RubricLab/blocks/commit/858b707b0c761cbd9cc9c7f000066fa37f06bdf0)
 - [2025-05-24] [basic renderer](https://github.com/RubricLab/blocks/commit/c69c2466ca2ca302498372201c79483e1e86c5c3)
 - [2025-05-22] [bump zod](https://github.com/RubricLab/blocks/commit/df96a8e52809595876d8add5f56391fb38e4b7d6)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# @rubriclab/actions
+The Blocks package aims to provide a powerful and simple way to define blocks (which are essentially UI primitives) and execute them safely with JSON serializable payloads.
+
+It is part of Rubric's architecture for Generative UI when used with:
+- @rubriclab/blocks
+- @rubriclab/chains
+- @rubriclab/agents
+- @rubriclab/events
+
+## Get Started
+### Installation
+`bun add @rubriclab/blocks`
+
+> @rubriclab scope packages are not built, they are all raw typescript. If using in a next.js app, make sure to transpile.
+
+```ts
+// next.config.ts
+import type { NextConfig } from  'next' 
+export default {
+	transpilePackages: ['@rubriclab/blocks'],
+	reactStrictMode: true
+} satisfies  NextConfig
+```
+
+> If using inside the monorepo (@rubric), simply add `{"@rubriclab/blocks": "*"}` to dependencies and then run `bun i`
+
+### Define Blocks
+To get started, define a few blocks.
+
+```tsx
+import { createBlock } from '@rubriclab/blocks'
+import { Heading } from '~/ui/heading'
+import { z } from 'zod'
+
+const heading = createBlock({
+	schema: {
+		input: {
+			text: z.string()
+		},
+		output: z.undefined
+	},
+	render: ({ text }) => <h1>{text}</h1>
+})
+
+export const blocks = { heading }
+```
+
+### Create a Renderer
+Pass all your blocks into an render to get a function to render it.
+
+```ts
+'use client'
+
+import { createBlockRenderer } from '@rubriclab/blocks'
+import { blocks } from './blocks'
+
+export const { render } = createBlockRenderer({ blocks })
+```
+
+### Render a Block
+
+```ts
+const block = await render({
+    block: 'heading',
+    props: {
+        text: 'Hello World'
+    }
+})
+```

--- a/index.tsx
+++ b/index.tsx
@@ -1,22 +1,50 @@
 import type { AnyAction } from '@rubriclab/actions'
 import type { ReactNode } from 'react'
 import z from 'zod/v4'
-import type { $strict } from 'zod/v4/core'
+import type { $strict, JSONSchema } from 'zod/v4/core'
 
 export function createBlock<Input extends Record<string, z.ZodType>, Output extends z.ZodType>({
 	schema,
-	render
+	render,
+	description
 }: {
 	schema: { input: Input; output: Output }
 	render: (
-		input: z.infer<z.ZodObject<Input, $strict>>,
+		input: {
+			[key in keyof Input]: z.infer<Input[key]> | { react: ReactNode; value: z.infer<Input[key]> }
+		},
 		{ emit }: { emit: (output: z.infer<Output>) => void }
 	) => ReactNode
+	description: string | undefined
 }) {
 	return {
 		type: 'block' as const,
 		schema,
-		render
+		render,
+		description
+	}
+}
+
+export function createStatefulBlock<
+	Input extends Record<string, z.ZodType>,
+	Output extends z.ZodType
+>({
+	schema,
+	render,
+	description
+}: {
+	schema: { input: Input; output: Output }
+	render: (input: z.infer<z.ZodObject<Input, $strict>>) => {
+		react: ReactNode
+		state: z.infer<Output>
+	}
+	description: string | undefined
+}) {
+	return {
+		type: 'stateful-block' as const,
+		schema,
+		render,
+		description
 	}
 }
 
@@ -28,7 +56,20 @@ export type BlockWithoutRenderArgs<
 	render: (input: any, { emit }: { emit: (output: z.infer<Output>) => void }) => ReactNode
 }
 
-export type AnyBlock = BlockWithoutRenderArgs<Record<string, z.ZodType>, z.ZodType>
+export type StatefulBlockWithoutRenderArgs<
+	Input extends Record<string, z.ZodType>,
+	Output extends z.ZodType
+> = Omit<ReturnType<typeof createStatefulBlock<Input, Output>>, 'render'> & {
+	// biome-ignore lint/suspicious/noExplicitAny: this is required to support generic functions that need to extend a placeholder for Blocks.
+	render: (input: any) => {
+		react: ReactNode
+		state: z.infer<Output>
+	}
+}
+
+export type AnyBlock =
+	| BlockWithoutRenderArgs<Record<string, z.ZodType>, z.ZodType>
+	| StatefulBlockWithoutRenderArgs<Record<string, z.ZodType>, z.ZodType>
 
 export function createBlockProxy<Name extends string, Input extends Record<string, z.ZodType>>({
 	name,
@@ -88,22 +129,24 @@ export function createGenericActionExecutorBlock<
 	ChildrenOptions extends z.ZodUnion
 >({
 	actionOptions,
-	instantiate
+	instantiate,
+	description
 }: {
 	actionOptions: ActionOptions
 	instantiate: <ActionKey extends keyof ActionOptions>({
-		action
+		actionName
 	}: {
-		action: ActionKey
+		actionName: ActionKey
 	}) => ReturnType<
 		typeof createBlock<
-			{
-				inputs: z.ZodObject<ActionOptions[keyof ActionOptions]['schema']['input'], $strict>
-				onExecute: z.ZodArray<ChildrenOptions>
-			},
-			z.ZodVoid
+			ActionOptions[keyof ActionOptions]['schema']['input'],
+			//  & {
+			// 	onExecute: z.ZodArray<ChildrenOptions>
+			// }
+			z.ZodUndefined
 		>
 	>
+	description: string | undefined
 }) {
 	type Keys = keyof ActionOptions & string
 	const keys = Object.keys(actionOptions) as Keys[]
@@ -112,17 +155,24 @@ export function createGenericActionExecutorBlock<
 		type: 'action' as const,
 		schema: {
 			input: {
-				action: z.enum(keys)
+				actionName: z.enum(keys)
 			},
-			output: z.void()
+			output: z.undefined()
 		},
-		execute: async ({ action }: { action: Keys }) => {
-			return instantiate({ action })
-		}
+		execute: async ({ actionName }: { actionName: Keys }) => {
+			return instantiate({ actionName })
+		},
+		description
 	}
 }
 
-// export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>() {}
+export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>({
+	actionOptions
+}: {
+	actionOptions: ActionOptions
+}) {
+	return {}
+}
 
 // export function createGenericActionSelectorBlock<
 // 	ActionOptions extends Record<string, z.ZodType>
@@ -147,4 +197,37 @@ export function createBlockRenderer<BlockMap extends Record<string, AnyBlock>>({
 			return render(props, { emit })
 		}
 	}
+}
+
+export function createBlocksDocs<BlocksMap extends Record<string, AnyBlock>>({
+	blocks
+}: {
+	blocks: BlocksMap
+}) {
+	return Object.entries(blocks)
+		.map(
+			([
+				name,
+				{
+					schema: { input, output },
+					description
+				}
+			]) => `## ${String(name)}
+### Description:
+${description ?? 'No description provided'}
+### Input Schema:
+${JSON.stringify(
+	z.toJSONSchema(
+		createBlockProxy({
+			name,
+			input
+		})
+	),
+	null,
+	2
+)}
+### Output Schema:
+${JSON.stringify(z.toJSONSchema(output), null, 2)}`
+		)
+		.join('\n\n')
 }

--- a/index.tsx
+++ b/index.tsx
@@ -1,19 +1,16 @@
+import type { AnyAction } from '@rubriclab/actions'
 import type { ReactNode } from 'react'
 import z from 'zod/v4'
+import type { $strict } from 'zod/v4/core'
 
-export function createBlock<
-	I extends Record<string, z.ZodType>,
-	O extends z.ZodType
-	// AdditionalOptions extends Record<string, unknown> = never
->({
+export function createBlock<Input extends Record<string, z.ZodType>, Output extends z.ZodType>({
 	schema,
 	render
 }: {
-	schema: { input: I; output: O }
+	schema: { input: Input; output: Output }
 	render: (
-		input: { [K in keyof I]: z.infer<I[K]> },
-		{ emit }: { emit: (output: z.infer<O>) => void }
-		// & AdditionalOptions
+		input: z.infer<z.ZodObject<Input, $strict>>,
+		{ emit }: { emit: (output: z.infer<Output>) => void }
 	) => ReactNode
 }) {
 	return {
@@ -23,19 +20,25 @@ export function createBlock<
 	}
 }
 
-export type AnyBlock = ReturnType<typeof createBlock<Record<string, z.ZodType>, z.ZodType>>
+export type BlockWithoutRenderArgs<
+	Input extends Record<string, z.ZodType>,
+	Output extends z.ZodType
+> = Omit<ReturnType<typeof createBlock<Input, Output>>, 'render'> & {
+	// biome-ignore lint/suspicious/noExplicitAny: this is required to support generic functions that need to extend a placeholder for Blocks.
+	render: (input: any, { emit }: { emit: (output: z.infer<Output>) => void }) => ReactNode
+}
 
-export type BlockMap = Record<string, AnyBlock>
+export type AnyBlock = BlockWithoutRenderArgs<Record<string, z.ZodType>, z.ZodType>
 
-export function createBlockProxy<Name extends string, Block extends AnyBlock>({
+export function createBlockProxy<Name extends string, Input extends Record<string, z.ZodType>>({
 	name,
 	input
 }: {
 	name: Name
-	input: Block['schema']['input']
+	input: Input
 }) {
-	return z.strictObject({
-		block: z.literal(`block_${name}` as const),
+	return z.object({
+		block: z.literal(name),
 		props: z.object(input)
 	})
 }
@@ -81,7 +84,7 @@ export function createGenericTypeProviderBlock<
 }
 
 export function createGenericActionExecutorBlock<
-	ActionOptions extends Record<string, Omit<AnyAction, 'execute'>>,
+	ActionOptions extends Record<string, AnyAction>,
 	ChildrenOptions extends z.ZodUnion
 >({
 	actionOptions,
@@ -95,7 +98,7 @@ export function createGenericActionExecutorBlock<
 	}) => ReturnType<
 		typeof createBlock<
 			{
-				inputs: z.ZodObject<ActionOptions[keyof ActionOptions]['schema']['input']>
+				inputs: z.ZodObject<ActionOptions[keyof ActionOptions]['schema']['input'], $strict>
 				onExecute: z.ZodArray<ChildrenOptions>
 			},
 			z.ZodVoid
@@ -120,3 +123,21 @@ export function createGenericActionExecutorBlock<
 }
 
 export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>() {}
+
+export function createBlockRenderer<BlockMap extends Record<string, AnyBlock>>({
+	blocks
+}: {
+	blocks: BlockMap
+}) {
+	return {
+		render<BlockKey extends keyof BlockMap & string>({
+			block,
+			props
+		}: z.infer<
+			ReturnType<typeof createBlockProxy<BlockKey, BlockMap[BlockKey]['schema']['input']>>
+		>) {
+			const { render } = blocks[block] ?? (undefined as never)
+			return render(props, { emit: () => {} })
+		}
+	}
+}

--- a/index.tsx
+++ b/index.tsx
@@ -1,314 +1,122 @@
-import { createHash } from 'node:crypto'
-import type React from 'react'
-import { type ReactNode, useState } from 'react'
-import { z } from 'zod'
+import type { ReactNode } from 'react'
+import z from 'zod/v4'
 
-// biome-ignore lint/suspicious/noExplicitAny: single required "any" to not overwhelm generics
-type BlockDefinition<In extends z.ZodRawShape = any, Out extends z.ZodTypeAny = any> = {
-	schema: { input: z.ZodObject<In>; output: Out }
-	render: (arg0: z.infer<z.ZodObject<In>>, arg1: { emit: (v: z.infer<Out>) => void }) => ReactNode
-}
-
-export type AnyBlocks = Record<string, BlockDefinition>
-
-export function createBlock<In extends z.ZodRawShape, Out extends z.ZodTypeAny>(def: {
-	schema: { input: z.ZodObject<In>; output: Out }
-	render: (arg0: z.infer<z.ZodObject<In>>, arg1: { emit: (v: z.infer<Out>) => void }) => ReactNode
-}): BlockDefinition<In, Out> {
-	return def
-}
-
-const shortHash = (str: string) => createHash('sha1').update(str).digest('hex').slice(0, 8)
-const stableName = (schema: z.ZodTypeAny) => `Schema_${shortHash(generateSignature(schema))}`
-const stableDescribe = (schema: z.ZodTypeAny) =>
-	schema._def.description ? schema : schema.describe(stableName(schema))
-
-function makeNonEmptyUnion(schemas: z.ZodTypeAny[]) {
-	if (!schemas.length) throw new Error('No schemas')
-	return schemas.length === 1
-		? (schemas[0] ?? (undefined as never))
-		: z.union(schemas as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
-}
-
-function generateSignature(schema: z.ZodTypeAny): string {
-	const def = schema?._def
-	if (!def) return 'unknown'
-	switch (def.typeName) {
-		case z.ZodFirstPartyTypeKind.ZodString:
-			return 'string'
-		case z.ZodFirstPartyTypeKind.ZodNumber:
-			return 'number'
-		case z.ZodFirstPartyTypeKind.ZodBoolean:
-			return 'boolean'
-		case z.ZodFirstPartyTypeKind.ZodLiteral:
-			return `literal_${JSON.stringify(def.value)}`
-		case z.ZodFirstPartyTypeKind.ZodVoid:
-			return 'void'
-		case z.ZodFirstPartyTypeKind.ZodObject: {
-			const shape = def.shape()
-			const entries = Object.entries(shape)
-				.map(([k, v]) => `${k}-${generateSignature(v as z.ZodTypeAny)}`)
-				.sort()
-			return `object_${entries.join('_')}`
-		}
-		case z.ZodFirstPartyTypeKind.ZodUnion:
-			return `union_${(def.options as z.ZodTypeAny[]).map(generateSignature).sort().join('_or_')}`
-		case z.ZodFirstPartyTypeKind.ZodEnum:
-			return `enum_${def.values.sort().join('_')}`
-		case z.ZodFirstPartyTypeKind.ZodArray:
-			return `array_${generateSignature(def.type)}`
-		case z.ZodFirstPartyTypeKind.ZodNativeEnum:
-			return `native_enum_${Object.values(def.values).sort().join('_')}`
-		default:
-			return 'unknown'
+export function createBlock<
+	I extends Record<string, z.ZodType>,
+	O extends z.ZodType
+	// AdditionalOptions extends Record<string, unknown> = never
+>({
+	schema,
+	render
+}: {
+	schema: { input: I; output: O }
+	render: (
+		input: { [K in keyof I]: z.infer<I[K]> },
+		{ emit }: { emit: (output: z.infer<O>) => void }
+		// & AdditionalOptions
+	) => ReactNode
+}) {
+	return {
+		type: 'block' as const,
+		schema,
+		render
 	}
 }
 
-export function zodToJsonSchema(zodType: z.ZodTypeAny): unknown {
-	const def = zodType?._def
-	if (!def) return { type: 'unknown' }
-	switch (def.typeName) {
-		case z.ZodFirstPartyTypeKind.ZodString:
-			return { type: 'string' }
-		case z.ZodFirstPartyTypeKind.ZodNumber:
-			return { type: 'number' }
-		case z.ZodFirstPartyTypeKind.ZodBoolean:
-			return { type: 'boolean' }
-		case z.ZodFirstPartyTypeKind.ZodLiteral:
-			return { type: typeof def.value, const: def.value }
-		case z.ZodFirstPartyTypeKind.ZodVoid:
-			return { type: 'null', description: 'Represents void/no return value' }
-		case z.ZodFirstPartyTypeKind.ZodObject: {
-			const shape = def.shape()
-			const props: Record<string, unknown> = {}
-			const req: string[] = []
-			Object.entries(shape).map(([k, v]) => {
-				props[k] = zodToJsonSchema(v as z.ZodTypeAny)
-				req.push(k)
-			})
-			return { type: 'object', properties: props, required: req, additionalProperties: false }
-		}
-		case z.ZodFirstPartyTypeKind.ZodUnion: {
-			const unionDef = def as z.ZodUnionDef
-			return { anyOf: unionDef.options.map((opt: z.ZodTypeAny) => zodToJsonSchema(opt)) }
-		}
-		case z.ZodFirstPartyTypeKind.ZodEnum:
-			return { type: 'string', enum: def.values }
-		case z.ZodFirstPartyTypeKind.ZodArray:
-			return { type: 'array', items: zodToJsonSchema(def.type) }
-		case z.ZodFirstPartyTypeKind.ZodNativeEnum:
-			return { type: 'string', enum: Object.values(def.values) }
-		case z.ZodFirstPartyTypeKind.ZodOptional:
-			return zodToJsonSchema(def.innerType)
-		case z.ZodFirstPartyTypeKind.ZodDate:
-			return { type: 'string', format: 'date-time' }
-		case z.ZodFirstPartyTypeKind.ZodDefault:
-			return zodToJsonSchema(def.innerType)
-		case z.ZodFirstPartyTypeKind.ZodNullable:
-			return zodToJsonSchema(def.innerType)
-		default:
-			throw `Should not see this. This is a blocks package error. Unknown type: ${def.typeName}`
-	}
-}
+export type AnyBlock = ReturnType<typeof createBlock<Record<string, z.ZodType>, z.ZodType>>
 
-type InputOfBlock<B> = B extends BlockDefinition<infer S> ? z.infer<z.ZodObject<S>> : never
-type OutputOfBlock<B> = B extends BlockDefinition<infer _, infer O> ? z.infer<O> : never
+export type BlockMap = Record<string, AnyBlock>
 
-export type BlockInvocation<Blocks extends AnyBlocks, Name extends keyof Blocks> = {
-	block: Name
-	props: {
-		[P in keyof InputOfBlock<Blocks[Name]>]:
-			| InputOfBlock<Blocks[Name]>[P]
-			| BlockChain<Blocks, InputOfBlock<Blocks[Name]>[P]>
-	}
-}
-
-export type BlockChain<Blocks extends AnyBlocks, ExpectedOutput = unknown> = {
-	[K in keyof Blocks]: OutputOfBlock<Blocks[K]> extends ExpectedOutput
-		? BlockInvocation<Blocks, K>
-		: never
-}[keyof Blocks]
-
-export type OutputOfBlockChain<
-	Blocks extends AnyBlocks,
-	Chain extends BlockChain<Blocks>
-> = Chain extends BlockInvocation<Blocks, infer N> ? OutputOfBlock<Blocks[N]> : never
-
-function makeCustomResponseFormat<ParsedT>(
-	jsonSchema: Record<string, unknown>,
-	parser: (c: string) => ParsedT
-) {
-	const openAIFormat = {
-		type: 'json_schema' as const,
-		name: 'ui_format',
-		schema: jsonSchema
-	}
-
-	Object.defineProperties(openAIFormat, {
-		$brand: { value: 'auto-parseable-response-format', enumerable: false },
-		$parseRaw: { value: parser, enumerable: false }
+export function createBlockProxy<Name extends string, Block extends AnyBlock>({
+	name,
+	input
+}: {
+	name: Name
+	input: Block['schema']['input']
+}) {
+	return z.strictObject({
+		block: z.literal(`block_${name}` as const),
+		props: z.object(input)
 	})
-
-	return openAIFormat
 }
 
-export function createBlocksRenderer<Blocks extends AnyBlocks>(blocks: Blocks) {
-	const blocksByOutputName: Record<string, string[]> = {}
-	Object.entries(blocks).map(([name, block]) => {
-		const outName = stableName(block.schema.output)
-		if (!blocksByOutputName[outName]) blocksByOutputName[outName] = []
-		blocksByOutputName[outName].push(name)
-	})
-
-	const blockSchemas: Record<string, z.ZodTypeAny> = {}
-
-	const paramSchemaForType = (paramSchema: z.ZodTypeAny): z.ZodTypeAny => {
-		const outName = stableName(paramSchema)
-		const acts = (blocksByOutputName[outName] ?? [])
-			.map(n => blockSchemas[n])
-			.filter((x): x is z.ZodTypeAny => !!x)
-		return stableDescribe(
-			acts.length
-				? z.union([paramSchema, ...acts] as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
-				: paramSchema
-		)
-	}
-
-	const blockSchemaBuilders: Record<string, () => z.ZodTypeAny> = {}
-	Object.entries(blocks).map(([name, block]) => {
-		blockSchemaBuilders[name] = () => {
-			const shape = block.schema.input.shape
-			const propsShape: Record<string, z.ZodTypeAny> = {}
-			for (const key in shape) propsShape[key] = paramSchemaForType(shape[key])
-			return z.object({ block: z.literal(name), props: z.object(propsShape).strict() })
-		}
-	})
-
-	Object.keys(blocks).map(name => {
-		blockSchemas[name] = z.lazy(blockSchemaBuilders[name] ?? (undefined as never))
-	})
-
-	const BlockUnion = z.lazy(() => stableDescribe(makeNonEmptyUnion(Object.values(blockSchemas))))
-	const schemaBase = z.object({ ui: BlockUnion }).strict()
-	const schema = schemaBase as z.ZodType<{ ui: z.infer<typeof BlockUnion> }>
-
-	type AnyInvocation = BlockInvocation<Blocks, keyof Blocks>
-
-	const InvocationComponent: React.FC<{
-		invocation: AnyInvocation
-		onEmit?: (v: unknown) => void
-	}> = ({ invocation, onEmit }) => {
-		const { block: blockName, props } = invocation as BlockInvocation<Blocks, keyof Blocks>
-		const blockDef = blocks[blockName]
-		if (!blockDef) return null
-
-		const resolvedProps: Record<string, unknown> = {}
-		const children: ReactNode[] = []
-
-		Object.entries(props).map(([key, value]) => {
-			if (value && typeof value === 'object' && 'block' in value) {
-				const ChildInvocation = value as AnyInvocation
-				const [childVal, setChildVal] = useState<unknown>()
-				resolvedProps[key] = childVal as unknown
-				children.push(
-					<InvocationComponent
-						key={`${String(blockName)}-${key}`}
-						invocation={ChildInvocation}
-						onEmit={setChildVal}
-					/>
-				)
-			} else {
-				resolvedProps[key] = value as unknown
-			}
-		})
-
-		return (
-			<>
-				{blockDef.render(resolvedProps as never, { emit: onEmit ?? (() => {}) })}
-				{/* Render any nested invocation components */}
-				{children}
-			</>
-		)
-	}
-
-	function render<Chain extends BlockChain<Blocks>>(
-		invocation: Chain,
-		onEmit?: (v: OutputOfBlockChain<Blocks, Chain>) => void
-	): ReactNode {
-		return (
-			<InvocationComponent
-				invocation={invocation as AnyInvocation}
-				onEmit={onEmit as (v: unknown) => void}
-			/>
-		)
-	}
-
-	async function getBlockSchema<K extends keyof Blocks>(
-		blockName: K
-	): Promise<Blocks[K]['schema']['input']['shape']> {
-		const block = blocks[blockName]
-		if (!block) throw new Error(`Unknown block: ${String(blockName)}`)
-		const { shape } = block.schema.input
-		return JSON.parse(JSON.stringify(shape))
-	}
-
-	async function getBlockNames(): Promise<Array<keyof Blocks>> {
-		return Object.keys(blocks)
-	}
-
-	const definitions: Record<string, unknown> = {}
-	const ensureOutputDefinition = (schema: z.ZodTypeAny) => {
-		const name = stableName(schema)
-		if (!definitions[name]) definitions[name] = zodToJsonSchema(schema)
-		return name
-	}
-
-	Object.values(blocks).map(b => ensureOutputDefinition(b.schema.output))
-
-	const paramToJsonSchema = (paramSchema: z.ZodTypeAny) => {
-		const outName = stableName(paramSchema)
-		const base = zodToJsonSchema(paramSchema)
-		const refs = (blocksByOutputName[outName] ?? []).map(bName => ({
-			$ref: `#/definitions/${bName}Block`
-		}))
-		return refs.length ? { anyOf: [base, ...refs] } : base
-	}
-
-	Object.entries(blocks).map(([blockName, block]) => {
-		const shape = block.schema.input.shape
-		const props: Record<string, unknown> = {}
-		const req: string[] = []
-		for (const key in shape) {
-			props[key] = paramToJsonSchema(shape[key])
-			req.push(key)
-		}
-		definitions[`${blockName}Block`] = {
-			type: 'object',
-			properties: {
-				block: { type: 'string', const: blockName },
-				props: { type: 'object', properties: props, required: req, additionalProperties: false }
+export function createGenericTypeProviderBlock<
+	TypeOptions extends Record<string, { type: z.ZodType; compatabilities: z.ZodType }>,
+	ChildrenOptions extends z.ZodUnion,
+	AdditionalInput extends Record<string, z.ZodType>
+>({
+	typeOptions,
+	instantiate
+}: {
+	typeOptions: TypeOptions
+	instantiate: <TypeKey extends keyof TypeOptions & string>({
+		type
+	}: {
+		type: TypeKey
+	}) => ReturnType<
+		typeof createBlock<
+			AdditionalInput & {
+				hydrate: TypeOptions[keyof TypeOptions]['compatabilities']
+				children: z.ZodArray<ChildrenOptions>
 			},
-			required: ['block', 'props'],
-			additionalProperties: false
+			z.ZodVoid
+		>
+	>
+}) {
+	type Keys = keyof TypeOptions & string
+	const keys = Object.keys(typeOptions) as Keys[]
+
+	return {
+		type: 'action' as const,
+		schema: {
+			input: {
+				type: z.enum(keys)
+			},
+			output: z.void()
+		},
+		execute: async ({ type }: { type: Keys }) => {
+			return instantiate({ type })
 		}
-	})
-
-	const blockUnion = {
-		anyOf: Object.keys(blocks).map(bName => ({ $ref: `#/definitions/${bName}Block` }))
 	}
-
-	const jsonSchema = {
-		$schema: 'http://json-schema.org/draft-07/schema#',
-		type: 'object',
-		properties: { ui: blockUnion },
-		required: ['ui'],
-		additionalProperties: false,
-		definitions
-	}
-
-	const response_format = makeCustomResponseFormat<z.infer<typeof schema>>(jsonSchema, c =>
-		schema.parse(JSON.parse(c))
-	)
-
-	return { render, getBlockSchema, getBlockNames, schema, response_format }
 }
+
+export function createGenericActionExecutorBlock<
+	ActionOptions extends Record<string, Omit<AnyAction, 'execute'>>,
+	ChildrenOptions extends z.ZodUnion
+>({
+	actionOptions,
+	instantiate
+}: {
+	actionOptions: ActionOptions
+	instantiate: <ActionKey extends keyof ActionOptions>({
+		action
+	}: {
+		action: ActionKey
+	}) => ReturnType<
+		typeof createBlock<
+			{
+				inputs: z.ZodObject<ActionOptions[keyof ActionOptions]['schema']['input']>
+				onExecute: z.ZodArray<ChildrenOptions>
+			},
+			z.ZodVoid
+		>
+	>
+}) {
+	type Keys = keyof ActionOptions & string
+	const keys = Object.keys(actionOptions) as Keys[]
+
+	return {
+		type: 'action' as const,
+		schema: {
+			input: {
+				action: z.enum(keys)
+			},
+			output: z.void()
+		},
+		execute: async ({ action }: { action: Keys }) => {
+			return instantiate({ action })
+		}
+	}
+}
+
+export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>() {}

--- a/index.tsx
+++ b/index.tsx
@@ -1,7 +1,7 @@
 import type { AnyAction } from '@rubriclab/actions'
 import type { ReactNode } from 'react'
 import z from 'zod/v4'
-import type { $strict, JSONSchema } from 'zod/v4/core'
+import type { $strict } from 'zod/v4/core'
 
 export function createBlock<Input extends Record<string, z.ZodType>, Output extends z.ZodType>({
 	schema,
@@ -125,10 +125,7 @@ export function createGenericTypeProviderBlock<
 	}
 }
 
-export function createGenericActionExecutorBlock<
-	ActionOptions extends Record<string, AnyAction>,
-	ChildrenOptions extends z.ZodUnion
->({
+export function createGenericActionExecutorBlock<ActionOptions extends Record<string, AnyAction>>({
 	actionOptions,
 	instantiate,
 	description
@@ -167,13 +164,13 @@ export function createGenericActionExecutorBlock<
 	}
 }
 
-export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>({
-	actionOptions
-}: {
-	actionOptions: ActionOptions
-}) {
-	return {}
-}
+// export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>({
+// 	actionOptions
+// }: {
+// 	actionOptions: ActionOptions
+// }) {
+// 	return {}
+// }
 
 // export function createGenericActionSelectorBlock<
 // 	ActionOptions extends Record<string, z.ZodType>
@@ -195,7 +192,8 @@ export function createBlockRenderer<BlockMap extends Record<string, AnyBlock>>({
 			emit: (output: z.infer<BlockMap[BlockKey]['schema']['output']>) => void
 		}) {
 			const { render } = blocks[block] ?? (undefined as never)
-			return render(props, { emit })
+			// biome-ignore lint/suspicious/noExplicitAny: Fix this
+			return render(props, { emit: emit as any })
 		}
 	}
 }

--- a/index.tsx
+++ b/index.tsx
@@ -11,7 +11,8 @@ export function createBlock<Input extends Record<string, z.ZodType>, Output exte
 	schema: { input: Input; output: Output }
 	render: (
 		input: {
-			[key in keyof Input]: z.infer<Input[key]> | { react: ReactNode; value: z.infer<Input[key]> }
+			[key in keyof Input]: z.infer<Input[key]>
+			// | { react: ReactNode; value: z.infer<Input[key]> }
 		},
 		{ emit }: { emit: (output: z.infer<Output>) => void }
 	) => ReactNode

--- a/index.tsx
+++ b/index.tsx
@@ -122,11 +122,11 @@ export function createGenericActionExecutorBlock<
 	}
 }
 
-export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>() {}
+// export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>() {}
 
-export function createGenericActionSelectorBlock<
-	ActionOptions extends Record<string, z.ZodType>
->() {}
+// export function createGenericActionSelectorBlock<
+// 	ActionOptions extends Record<string, z.ZodType>
+// >() {}
 
 export function createBlockRenderer<BlockMap extends Record<string, AnyBlock>>({
 	blocks

--- a/index.tsx
+++ b/index.tsx
@@ -124,6 +124,10 @@ export function createGenericActionExecutorBlock<
 
 export function createGenericActionMapperBlock<ActionOptions extends Record<string, z.ZodType>>() {}
 
+export function createGenericActionSelectorBlock<
+	ActionOptions extends Record<string, z.ZodType>
+>() {}
+
 export function createBlockRenderer<BlockMap extends Record<string, AnyBlock>>({
 	blocks
 }: {
@@ -132,12 +136,15 @@ export function createBlockRenderer<BlockMap extends Record<string, AnyBlock>>({
 	return {
 		render<BlockKey extends keyof BlockMap & string>({
 			block,
-			props
+			props,
+			emit
 		}: z.infer<
 			ReturnType<typeof createBlockProxy<BlockKey, BlockMap[BlockKey]['schema']['input']>>
-		>) {
+		> & {
+			emit: (output: z.infer<BlockMap[BlockKey]['schema']['output']>) => void
+		}) {
 			const { render } = blocks[block] ?? (undefined as never)
-			return render(props, { emit: () => {} })
+			return render(props, { emit })
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "lint:fix": "bun x biome check --fix --unsafe . && bun x biome lint --write --unsafe ."
   },
   "name": "@rubriclab/blocks",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "index.ts",
   "dependencies": {
     "@rubriclab/package": "*",
-    "@rubriclab/config": "*"
+    "@rubriclab/config": "*",
+    "zod": "3.25.20"
   },
   "simple-git-hooks": {
     "post-commit": "bun run rubriclab-postcommit"

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-  "scripts": {
-    "generate": "bun scripts/generate.ts",
-    "watch": "bun scripts/watch.ts",
-    "prepare": "bun x simple-git-hooks",
-    "bleed": "bun x npm-check-updates -u && bun i",
-    "clean": "rm -rf .next && rm -rf node_modules",
-    "format": "bun x biome format --write .",
-    "lint": "bun x biome check . && bun x biome lint .",
-    "lint:fix": "bun x biome check --fix --unsafe . && bun x biome lint --write --unsafe ."
-  },
-  "name": "@rubriclab/blocks",
-  "version": "0.0.10",
-  "main": "index.ts",
-  "dependencies": {
-    "@rubriclab/package": "*",
-    "@rubriclab/config": "*",
-    "zod": "latest"
-  },
-  "simple-git-hooks": {
-    "post-commit": "bun run rubriclab-postcommit"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"scripts": {
+		"generate": "bun scripts/generate.ts",
+		"watch": "bun scripts/watch.ts",
+		"prepare": "bun x simple-git-hooks",
+		"bleed": "bun x npm-check-updates -u && bun i",
+		"clean": "rm -rf .next && rm -rf node_modules",
+		"format": "bun x biome format --write .",
+		"lint": "bun x biome check . && bun x biome lint .",
+		"lint:fix": "bun x biome check --fix --unsafe . && bun x biome lint --write --unsafe ."
+	},
+	"name": "@rubriclab/blocks",
+	"version": "0.0.11",
+	"main": "index.ts",
+	"dependencies": {
+		"@rubriclab/package": "*",
+		"@rubriclab/config": "*",
+		"zod": "latest"
+	},
+	"simple-git-hooks": {
+		"post-commit": "bun run rubriclab-postcommit"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "lint:fix": "bun x biome check --fix --unsafe . && bun x biome lint --write --unsafe ."
   },
   "name": "@rubriclab/blocks",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "index.ts",
   "dependencies": {
     "@rubriclab/package": "*",
     "@rubriclab/config": "*",
-    "zod": "3.25.21"
+    "zod": "latest"
   },
   "simple-git-hooks": {
     "post-commit": "bun run rubriclab-postcommit"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "bun x biome check --fix --unsafe . && bun x biome lint --write --unsafe ."
   },
   "name": "@rubriclab/blocks",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "index.ts",
   "dependencies": {
     "@rubriclab/package": "*",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "lint:fix": "bun x biome check --fix --unsafe . && bun x biome lint --write --unsafe ."
   },
   "name": "@rubriclab/blocks",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "index.ts",
   "dependencies": {
     "@rubriclab/package": "*",
     "@rubriclab/config": "*",
-    "zod": "3.25.20"
+    "zod": "3.25.21"
   },
   "simple-git-hooks": {
     "post-commit": "bun run rubriclab-postcommit"


### PR DESCRIPTION
This is a coordinated PR across multiple packages that represents a re-arch of the Rubric GEN UI stack
- [Agents PR](https://github.com/RubricLab/agents/pull/1) (this)
- [Events PR](https://github.com/RubricLab/events/pull/2)
- [Actions PR](https://github.com/RubricLab/actions/pull/1)
- [Blocks PR](https://github.com/RubricLab/blocks/pull/2)
- [Chains Repo](https://github.com/RubricLab/chains) (new)
- [Chat App PR](https://github.com/RubricLab/chat/pull/2) (demo)

### TODO
- [x] migrate to zod/v4
- [x] createBlock
- [x] createGenericActionExecutorBlock
- [ ] createGenericActionMapperBlock
- [x] createBlockRenderer
- [x] createBlocksDocs
- [x] documentation